### PR TITLE
Validate arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ program
     program.outputHelp();
     console.log(`\n Unknown command ${cmd).`));
     console.log();
-  }); 
+  }) 
 .parse(process.argv);
 
 if (!program.args.length) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,17 @@ program
 .option('-u, --update', 'Self update')
 .option('-e, --enable', 'Enable Auto Commit')
 .option('-d, --disable', 'Disable Auto Commit')
+.arguments('<command>')
+  .action((cmd) => {
+    program.outputHelp();
+    console.log(`\n Unknown command ${cmd).`));
+    console.log();
+  }); 
 .parse(process.argv);
+
+if (!program.args.length) {
+  program.outputHelp();
+}
 
 function sleep(ms) {
   return new Promise(function(resolve, reject) {


### PR DESCRIPTION
> Closes #10

* Currently, firing in `g3l` without any sort of arguments won't produce anything. I think it is a good idea to have help showing up if that's the case :thinking: 
* Warns the user if he fires in unknown commands